### PR TITLE
Fixed getting settings and creating custom field

### DIFF
--- a/lib/custom_fields.js
+++ b/lib/custom_fields.js
@@ -2,10 +2,10 @@ import Telescope from 'meteor/nova:lib';
 import PublicationUtils from 'meteor/utilities:smart-publications';
 import Upload from './components/Upload.jsx';
 import checkSettings from './utils.js';
+import Users from 'meteor/nova:users';
 
-
-if (typeof Package['nova:users'] === 'object' && checkSettings()) {
-  import Users from 'meteor/nova:users';
+if ( checkSettings() ) {
+  
 
   // check if user can create a new account
   const canInsert = user => Users.canDo(user, "users.new");
@@ -24,7 +24,7 @@ if (typeof Package['nova:users'] === 'object' && checkSettings()) {
       editableIf: canEdit,
       autoform: {
         options: {
-          preset: Telescope.settings.get('cloudinaryPresets').avatar
+          preset: preset: Meteor.settings.cloudinaryPresets.avatar
         },
       }
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,9 @@
 import Telescope from 'meteor/nova:lib';
 
-// function used to avoid bug and block the usage of the package: return false if settings are invalid
-//const checkSettings = () => typeof Telescope.settings.get('cloudinaryCloudName') === 'string' && typeof Telescope.settings.get('cloudinaryPresets') === 'object';
+// function used to avoid bug and block the usage of the package: return false if settings are invalid 
+const checkSettings = () => Telescope.settings != "undefined" && typeof Telescope.settings.get('cloudinaryCloudName') === 'string' && typeof Telescope.settings.get('cloudinaryPresets') === 'object';
 
-const checkSettings = () => Meteor.settings && Meteor.settings.cloudinaryCloudName && Meteor.settings.cloudinaryPresets;
+//better use this?
+//const checkSettings = () => Meteor.settings && Meteor.settings.cloudinaryCloudName && Meteor.settings.cloudinaryPresets;
 
 export default checkSettings;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,8 @@
 import Telescope from 'meteor/nova:lib';
 
 // function used to avoid bug and block the usage of the package: return false if settings are invalid
-const checkSettings = () => typeof Telescope.settings.get('cloudinaryCloudName') === 'string' && typeof Telescope.settings.get('cloudinaryPresets') === 'object';
+//const checkSettings = () => typeof Telescope.settings.get('cloudinaryCloudName') === 'string' && typeof Telescope.settings.get('cloudinaryPresets') === 'object';
+
+const checkSettings = () => Meteor.settings && Meteor.settings.cloudinaryCloudName && Meteor.settings.cloudinaryPresets;
 
 export default checkSettings;


### PR DESCRIPTION
Hello Xavi :)

thanks for this package but I got this error:

``````

W20160831-02:55:40.700(0)? (STDERR)     import Users from 'meteor/nova:users';                                    
W20160831-02:55:40.701(0)? (STDERR)     ^^^^^^
W20160831-02:55:40.707(0)? (STDERR) SyntaxError: Unexpected reserved word
W20160831-02:55:40.707(0)? (STDERR)     at /home/ubuntu/workspace/main/.meteor/local/build/programs/server/boot.js:278:30
W20160831-02:55:40.708(0)? (STDERR)     at Array.forEach (native)```
``````

you are importing the users after an if ?
why?

I changed that to 

`if ( checkSettings() ) {//typeof Package['nova:users'] === 'object' &&`

and it works

but after that I got this :

```
 TypeError: Cannot call method 'get' of undefined
W20160831-02:58:57.450(0)? (STDERR)     at checkSettings (packages/xavcz:nova-forms-upload/lib/utils.js:4:55)
```

so I fixed all of that by changing this code 

const checkSettings = () => Meteor.settings && Meteor.settings.cloudinaryCloudName && Meteor.settings.cloudinaryPresets;
